### PR TITLE
v0.2.3 tsbuildinfo on logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ This project is in early development and mostly for personal use. It's planned t
 
 This will create a new folder with the specified project name and set up a base Express/TypeScript project inside.
 
+### npx
+You can also use `npx` to use Simply Express Generator without installing globally:
+
+```bash
+npx simply-express-generator new <project-name>
+```
+
 ## Options
 
 Simply Express Generator will ask you if you want to overwrite if the project directory already exists, you can bypass this with the `-o --overwrite` flag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simply-express-generator",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simply-express-generator",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "ISC",
       "dependencies": {
         "commander": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simply-express-generator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A simple express generator utility for barebones Express/TS projects",
   "main": "dist/index.js",
   "bin": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "tsBuildInfoFile": "logs/.tsbuildinfo",
     "target": "ES2017",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
This patch version comes with the following changes:
* Changed the tsBuildInfoFile directory to the logs/ so it won't bundle with the npm package, reducing drastically the package size.
* Added npx usage section to the README.